### PR TITLE
move require() to screenshotMode plugin

### DIFF
--- a/src/plugins/screenshot_mode/common/get_set_browser_screenshot_mode.ts
+++ b/src/plugins/screenshot_mode/common/get_set_browser_screenshot_mode.ts
@@ -15,9 +15,9 @@ export const KBN_SCREENSHOT_MODE_ENABLED_KEY = '__KBN_SCREENSHOT_MODE_ENABLED_KE
  * localStorage. The ability to set a value in localStorage enables more convenient development and testing
  * in functionality that needs to detect screenshot mode.
  */
-export const getScreenshotMode = (): unknown => {
+export const getScreenshotMode = (): boolean => {
   return (
-    ((window as unknown) as Record<string, unknown>)[KBN_SCREENSHOT_MODE_ENABLED_KEY] ||
+    Boolean(((window as unknown) as Record<string, unknown>)[KBN_SCREENSHOT_MODE_ENABLED_KEY]) ||
     window.localStorage.getItem(KBN_SCREENSHOT_MODE_ENABLED_KEY) === 'true'
   );
 };

--- a/src/plugins/screenshot_mode/server/index.ts
+++ b/src/plugins/screenshot_mode/server/index.ts
@@ -12,6 +12,8 @@ export { setScreenshotModeEnabled, KBN_SCREENSHOT_MODE_HEADER } from '../common'
 
 export { ScreenshotModeRequestHandlerContext } from './types';
 
+export { ScreenshotModePluginSetup } from './plugin';
+
 export function plugin() {
   return new ScreenshotModePlugin();
 }

--- a/src/plugins/screenshot_mode/server/plugin.ts
+++ b/src/plugins/screenshot_mode/server/plugin.ts
@@ -10,7 +10,11 @@ import { Plugin, CoreSetup } from '../../../core/server';
 import { KBN_SCREENSHOT_MODE_HEADER } from '../common';
 import { ScreenshotModeRequestHandlerContext } from './types';
 
-export class ScreenshotModePlugin implements Plugin {
+export interface ScreenshotModePluginSetup {
+  setScreenshotModeEnabled: () => void;
+}
+
+export class ScreenshotModePlugin implements Plugin<ScreenshotModePluginSetup> {
   public setup(core: CoreSetup) {
     core.http.registerRouteHandlerContext<ScreenshotModeRequestHandlerContext, 'screenshotMode'>(
       'screenshotMode',
@@ -22,6 +26,15 @@ export class ScreenshotModePlugin implements Plugin {
         };
       }
     );
+
+    // We use "require" here to ensure the import does not have external references due to code bundling that
+    // commonly happens during transpiling which would be missing in the environment puppeteer creates.
+    // eslint-disable-next-line @typescript-eslint/no-var-requires
+    const { setScreenshotModeEnabled } = require('../');
+
+    return {
+      setScreenshotModeEnabled,
+    };
   }
 
   public start() {}

--- a/x-pack/plugins/reporting/server/browsers/chromium/driver/chromium_driver.ts
+++ b/x-pack/plugins/reporting/server/browsers/chromium/driver/chromium_driver.ts
@@ -10,19 +10,14 @@ import { map, truncate } from 'lodash';
 import open from 'opn';
 import puppeteer, { ElementHandle, EvaluateFn, SerializableOrJSHandle } from 'puppeteer';
 import { parse as parseUrl } from 'url';
-import { KBN_SCREENSHOT_MODE_HEADER } from '../../../../../../../src/plugins/screenshot_mode/server';
 import { getDisallowedOutgoingUrlError } from '../';
+import { ReportingCore } from '../../..';
+import { KBN_SCREENSHOT_MODE_HEADER } from '../../../../../../../src/plugins/screenshot_mode/server';
 import { ConditionalHeaders, ConditionalHeadersConditions } from '../../../export_types/common';
 import { LevelLogger } from '../../../lib';
 import { ViewZoomWidthHeight } from '../../../lib/layouts/layout';
 import { ElementPosition } from '../../../lib/screenshots';
 import { allowRequest, NetworkPolicy } from '../../network_policy';
-
-// We use "require" here to ensure the import does not have external references due to code bundling that
-// commonly happens during transpiling which would be missing in the environment puppeteer creates.
-// eslint-disable-next-line @typescript-eslint/no-var-requires
-const setScreenshotModeEnabled = require('../../../../../../../src/plugins/screenshot_mode/server')
-  .setScreenshotModeEnabled;
 
 export interface ChromiumDriverOptions {
   inspect: boolean;
@@ -66,8 +61,14 @@ export class HeadlessChromiumDriver {
 
   private listenersAttached = false;
   private interceptedCount = 0;
+  private core: ReportingCore;
 
-  constructor(page: puppeteer.Page, { inspect, networkPolicy }: ChromiumDriverOptions) {
+  constructor(
+    core: ReportingCore,
+    page: puppeteer.Page,
+    { inspect, networkPolicy }: ChromiumDriverOptions
+  ) {
+    this.core = core;
     this.page = page;
     this.inspect = inspect;
     this.networkPolicy = networkPolicy;
@@ -105,7 +106,9 @@ export class HeadlessChromiumDriver {
     // Reset intercepted request count
     this.interceptedCount = 0;
 
-    await this.page.evaluateOnNewDocument(setScreenshotModeEnabled);
+    const enableScreenshotMode = this.core.enableScreenshotMode();
+
+    await this.page.evaluateOnNewDocument(enableScreenshotMode);
     await this.page.setRequestInterception(true);
 
     this.registerListeners(conditionalHeaders, logger);

--- a/x-pack/plugins/reporting/server/browsers/chromium/driver/chromium_driver.ts
+++ b/x-pack/plugins/reporting/server/browsers/chromium/driver/chromium_driver.ts
@@ -107,7 +107,6 @@ export class HeadlessChromiumDriver {
     this.interceptedCount = 0;
 
     const enableScreenshotMode = this.core.enableScreenshotMode();
-
     await this.page.evaluateOnNewDocument(enableScreenshotMode);
     await this.page.setRequestInterception(true);
 

--- a/x-pack/plugins/reporting/server/browsers/chromium/driver_factory/index.ts
+++ b/x-pack/plugins/reporting/server/browsers/chromium/driver_factory/index.ts
@@ -15,6 +15,7 @@ import * as Rx from 'rxjs';
 import { InnerSubscriber } from 'rxjs/internal/InnerSubscriber';
 import { ignoreElements, map, mergeMap, tap } from 'rxjs/operators';
 import { getChromiumDisconnectedError } from '../';
+import { ReportingCore } from '../../..';
 import { BROWSER_TYPE } from '../../../../common/constants';
 import { durationToNumber } from '../../../../common/schema_utils';
 import { CaptureConfig } from '../../../../server/types';
@@ -32,11 +33,14 @@ export class HeadlessChromiumDriverFactory {
   private browserConfig: BrowserConfig;
   private userDataDir: string;
   private getChromiumArgs: (viewport: ViewportConfig) => string[];
+  private core: ReportingCore;
 
-  constructor(binaryPath: string, captureConfig: CaptureConfig, logger: LevelLogger) {
+  constructor(core: ReportingCore, binaryPath: string, logger: LevelLogger) {
+    this.core = core;
     this.binaryPath = binaryPath;
-    this.captureConfig = captureConfig;
-    this.browserConfig = captureConfig.browser.chromium;
+    const config = core.getConfig();
+    this.captureConfig = config.get('capture');
+    this.browserConfig = this.captureConfig.browser.chromium;
 
     if (this.browserConfig.disableSandbox) {
       logger.warning(`Enabling the Chromium sandbox provides an additional layer of protection.`);
@@ -138,7 +142,7 @@ export class HeadlessChromiumDriverFactory {
       this.getProcessLogger(browser, logger).subscribe();
 
       // HeadlessChromiumDriver: object to "drive" a browser page
-      const driver = new HeadlessChromiumDriver(page, {
+      const driver = new HeadlessChromiumDriver(this.core, page, {
         inspect: !!this.browserConfig.inspect,
         networkPolicy: this.captureConfig.networkPolicy,
       });

--- a/x-pack/plugins/reporting/server/browsers/chromium/index.ts
+++ b/x-pack/plugins/reporting/server/browsers/chromium/index.ts
@@ -7,15 +7,15 @@
 
 import { i18n } from '@kbn/i18n';
 import { BrowserDownload } from '../';
-import { CaptureConfig } from '../../../server/types';
+import { ReportingCore } from '../../../server';
 import { LevelLogger } from '../../lib';
 import { HeadlessChromiumDriverFactory } from './driver_factory';
 import { ChromiumArchivePaths } from './paths';
 
 export const chromium: BrowserDownload = {
   paths: new ChromiumArchivePaths(),
-  createDriverFactory: (binaryPath: string, captureConfig: CaptureConfig, logger: LevelLogger) =>
-    new HeadlessChromiumDriverFactory(binaryPath, captureConfig, logger),
+  createDriverFactory: (core: ReportingCore, binaryPath: string, logger: LevelLogger) =>
+    new HeadlessChromiumDriverFactory(core, binaryPath, logger),
 };
 
 export const getChromiumDisconnectedError = () =>

--- a/x-pack/plugins/reporting/server/browsers/index.ts
+++ b/x-pack/plugins/reporting/server/browsers/index.ts
@@ -6,9 +6,8 @@
  */
 
 import { first } from 'rxjs/operators';
-import { ReportingConfig } from '../';
+import { ReportingCore } from '../';
 import { LevelLogger } from '../lib';
-import { CaptureConfig } from '../types';
 import { chromium, ChromiumArchivePaths } from './chromium';
 import { HeadlessChromiumDriverFactory } from './chromium/driver_factory';
 import { installBrowser } from './install';
@@ -18,8 +17,8 @@ export { HeadlessChromiumDriver } from './chromium/driver';
 export { HeadlessChromiumDriverFactory } from './chromium/driver_factory';
 
 type CreateDriverFactory = (
+  core: ReportingCore,
   binaryPath: string,
-  captureConfig: CaptureConfig,
   logger: LevelLogger
 ) => HeadlessChromiumDriverFactory;
 
@@ -28,12 +27,8 @@ export interface BrowserDownload {
   paths: ChromiumArchivePaths;
 }
 
-export const initializeBrowserDriverFactory = async (
-  config: ReportingConfig,
-  logger: LevelLogger
-) => {
+export const initializeBrowserDriverFactory = async (core: ReportingCore, logger: LevelLogger) => {
   const { binaryPath$ } = installBrowser(logger);
   const binaryPath = await binaryPath$.pipe(first()).toPromise();
-  const captureConfig = config.get('capture');
-  return chromium.createDriverFactory(binaryPath, captureConfig, logger);
+  return chromium.createDriverFactory(core, binaryPath, logger);
 };

--- a/x-pack/plugins/reporting/server/core.ts
+++ b/x-pack/plugins/reporting/server/core.ts
@@ -8,6 +8,7 @@
 import Hapi from '@hapi/hapi';
 import * as Rx from 'rxjs';
 import { first, map, take } from 'rxjs/operators';
+import { ScreenshotModePluginSetup } from 'src/plugins/screenshot_mode/server';
 import {
   BasePath,
   IClusterClient,
@@ -41,6 +42,7 @@ export interface ReportingInternalSetup {
   security?: SecurityPluginSetup;
   spaces?: SpacesPluginSetup;
   taskManager: TaskManagerSetupContract;
+  screenshotMode: ScreenshotModePluginSetup;
   logger: LevelLogger;
 }
 
@@ -235,6 +237,11 @@ export class ReportingCore {
     const config = this.getConfig();
     const { browserDriverFactory } = await this.getPluginStartDeps();
     return screenshotsObservableFactory(config.get('capture'), browserDriverFactory);
+  }
+
+  public enableScreenshotMode() {
+    const { screenshotMode } = this.getPluginSetupDeps();
+    return screenshotMode.setScreenshotModeEnabled;
   }
 
   /*

--- a/x-pack/plugins/reporting/server/plugin.ts
+++ b/x-pack/plugins/reporting/server/plugin.ts
@@ -48,12 +48,13 @@ export class ReportingPlugin
     registerUiSettings(core);
 
     const { http } = core;
-    const { features, licensing, security, spaces, taskManager } = plugins;
+    const { screenshotMode, features, licensing, security, spaces, taskManager } = plugins;
 
     const router = http.createRouter<ReportingRequestHandlerContext>();
     const basePath = http.basePath;
 
     reportingCore.pluginSetup({
+      screenshotMode,
       features,
       licensing,
       basePath,
@@ -91,9 +92,8 @@ export class ReportingPlugin
     // async background start
     (async () => {
       await reportingCore.pluginSetsUp();
-      const config = reportingCore.getConfig();
 
-      const browserDriverFactory = await initializeBrowserDriverFactory(config, this.logger);
+      const browserDriverFactory = await initializeBrowserDriverFactory(reportingCore, this.logger);
       const store = new ReportingStore(reportingCore, this.logger);
 
       await reportingCore.pluginStart({

--- a/x-pack/plugins/reporting/server/test_helpers/create_mock_browserdriverfactory.ts
+++ b/x-pack/plugins/reporting/server/test_helpers/create_mock_browserdriverfactory.ts
@@ -8,6 +8,7 @@
 import moment from 'moment';
 import { Page } from 'puppeteer';
 import * as Rx from 'rxjs';
+import { ReportingCore } from '..';
 import { chromium, HeadlessChromiumDriver, HeadlessChromiumDriverFactory } from '../browsers';
 import { LevelLogger } from '../lib';
 import { ElementsPositionAndAttribute } from '../lib/screenshots';
@@ -96,6 +97,7 @@ const defaultOpts: CreateMockBrowserDriverFactoryOpts = {
 };
 
 export const createMockBrowserDriverFactory = async (
+  core: ReportingCore,
   logger: LevelLogger,
   opts: Partial<CreateMockBrowserDriverFactoryOpts> = {}
 ): Promise<HeadlessChromiumDriverFactory> => {
@@ -122,9 +124,9 @@ export const createMockBrowserDriverFactory = async (
   };
 
   const binaryPath = '/usr/local/share/common/secure/super_awesome_binary';
-  const mockBrowserDriverFactory = chromium.createDriverFactory(binaryPath, captureConfig, logger);
+  const mockBrowserDriverFactory = chromium.createDriverFactory(core, binaryPath, logger);
   const mockPage = ({ setViewport: () => {} } as unknown) as Page;
-  const mockBrowserDriver = new HeadlessChromiumDriver(mockPage, {
+  const mockBrowserDriver = new HeadlessChromiumDriver(core, mockPage, {
     inspect: true,
     networkPolicy: captureConfig.networkPolicy,
   });

--- a/x-pack/plugins/reporting/server/types.ts
+++ b/x-pack/plugins/reporting/server/types.ts
@@ -8,6 +8,7 @@
 import type { IRouter, KibanaRequest, RequestHandlerContext } from 'src/core/server';
 // eslint-disable-next-line @kbn/eslint/no-restricted-paths
 import { DataPluginStart } from 'src/plugins/data/server/plugin';
+import { ScreenshotModePluginSetup } from 'src/plugins/screenshot_mode/server';
 import { UsageCollectionSetup } from 'src/plugins/usage_collection/server';
 import { PluginSetupContract as FeaturesPluginSetup } from '../../features/server';
 import { LicensingPluginSetup } from '../../licensing/server';
@@ -32,6 +33,7 @@ export interface ReportingSetupDeps {
   spaces?: SpacesPluginSetup;
   taskManager: TaskManagerSetupContract;
   usageCollection?: UsageCollectionSetup;
+  screenshotMode: ScreenshotModePluginSetup;
 }
 
 export interface ReportingStartDeps {


### PR DESCRIPTION
Moves the `require` statement to the ScreenshotMode Plugin
Adds a method to ReportingCore to expose `setScreenshotModeEnabled` to downstream code
Adds the ReportingCore object the function signatures of code that needs `setScreenshotModeEnabled` in its downstream