### PR TITLE
Improve discover search session relative time range test

### DIFF
--- a/x-pack/test/functional/page_objects/search_sessions_management_page.ts
+++ b/x-pack/test/functional/page_objects/search_sessions_management_page.ts
@@ -38,6 +38,7 @@ export function SearchSessionsPageProvider({ getService, getPageObjects }: FtrPr
             mainUrl: $.findTestSubject('sessionManagementNameCol').text(),
             created: $.findTestSubject('sessionManagementCreatedCol').text(),
             expires: $.findTestSubject('sessionManagementExpiresCol').text(),
+            searchesCount: Number($.findTestSubject('sessionManagementNumSearchesCol').text()),
             app: $.findTestSubject('sessionManagementAppIcon').attr('data-test-app-id'),
             view: async () => {
               log.debug('management ui: view the session');


### PR DESCRIPTION
We check that there is no warnings when restoring the sessions and also check that no new searces were added into the session when restoring it.