### PR TITLE
Update saved object mapping guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,6 +13,10 @@
 - Modules are grouped by domain (platform vs solutions) with visibility rules (`shared` vs `private`) that limit cross-group access.
 - Utility scripts live in `scripts/` (e.g., `node scripts/generate.js`).
 
+## Saved Objects
+- Do not eagerly add Saved Object type mappings. Ask the feature author for explicit permission for each field they want mapped. Mapped fields are not SQL table columns: once added, they cannot be removed, and they should only be used to power search functionality for the feature.
+- Do not add type mappings for fields that already exist in the Saved Object root mappings. Current root mapped fields are `type`, `namespace`, `namespaces`, `originId`, `updated_at`, `updated_by`, `created_at`, `created_by`, `references`, `coreMigrationVersion`, `typeMigrationVersion`, `managed`, and `accessControl`; check `src/core/packages/saved-objects/migration-server-internal/src/core/build_active_mappings.ts` for the authoritative list.
+
 ## Critical Thinking
 - Fix root cause (not band-aid).
 - Unsure: read more code; if still stuck, ask w/ short options. Never guess.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,8 +14,8 @@
 - Utility scripts live in `scripts/` (e.g., `node scripts/generate.js`).
 
 ## Saved Objects
-- Do not eagerly add Saved Object type mappings. Ask the feature author for explicit permission for each field they want mapped. Mapped fields are not SQL table columns: once added, they cannot be removed, and they should only be used to power search functionality for the feature.
-- Do not add type mappings for fields that already exist in the Saved Object root mappings. Current root mapped fields are `type`, `namespace`, `namespaces`, `originId`, `updated_at`, `updated_by`, `created_at`, `created_by`, `references`, `coreMigrationVersion`, `typeMigrationVersion`, `managed`, and `accessControl`; check `src/core/packages/saved-objects/migration-server-internal/src/core/build_active_mappings.ts` for the authoritative list.
+- Do not eagerly add Saved Object type mappings. Ask the feature author to confirm each mapped field is needed for feature search; mapped fields are not SQL columns and cannot be removed once added.
+- Do not map fields already covered by root mappings (for example, `created_at`). Inspect the authoritative source by searching for `getBaseMappings` in `src/core/packages/saved-objects`.
 
 ## Critical Thinking
 - Fix root cause (not band-aid).


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Updates `AGENTS.md` with brief saved object mapping guidance:
- Ask feature authors to confirm mapped fields are needed for feature search.
- Warn that mapped fields are not SQL columns and cannot be removed once added.
- Point agents to `getBaseMappings` instead of hardcoding the current root mapping list.

### Checklist

- [x] Documentation-only change; no tests required.
- [x] Release note not required.

### Identify risks

No runtime risk; guidance-only change.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-972007c4-1aa4-48bc-93ca-d9869fa09334"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-972007c4-1aa4-48bc-93ca-d9869fa09334"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

